### PR TITLE
Fix physmem r

### DIFF
--- a/PlatboxClient/src/amd/amd_chipset.cpp
+++ b/PlatboxClient/src/amd/amd_chipset.cpp
@@ -712,7 +712,7 @@ void amd_dump_spi_flash(const char *output_filename) {
     lpc_rom_addr_range2.StartAddr = (DWORD)g_lpc_isa_bridge_registers.LPC_ROM_Address_Range_2_StartAddress << 16;
     lpc_rom_addr_range2.EndAddr = ((DWORD)g_lpc_isa_bridge_registers.LPC_ROM_Address_Range_2_EndAddress << 16) | 0xffff;
 
-    size_t rom_size = lpc_rom_addr_range2.EndAddr - lpc_rom_addr_range2.StartAddr;
+    size_t rom_size = lpc_rom_addr_range2.EndAddr - lpc_rom_addr_range2.StartAddr + 1;
     char *rom_data  = (char *) calloc(1, rom_size);
     
     debug_print(" -> About to read %08x bytes from %016llx pa\n", rom_size, lpc_rom_addr_range2.StartAddr);

--- a/PlatboxClient/src/physmem.cpp
+++ b/PlatboxClient/src/physmem.cpp
@@ -182,7 +182,7 @@ void read_physical_memory(UINT64 address, UINT32 size, PVOID buffer, BOOL bPrint
 				}
 
 				if (bPrint) {
-					print_memory(cur_address, (char *)physmem_addr, PAGE_SIZE);
+					print_memory(cur_address, (char *)physmem_addr, auxSize);
 				}
 
 				munmap(physmem_addr, PAGE_SIZE);


### PR DESCRIPTION
This PR fixes the number of bytes that will be printed in the case of the `physmem r` command.
Currently (in the case of Linux) a number of bytes will be printed which is always a multiple of `PAGE_SIZE`.