### PR TITLE
amd_chipset.cpp: _read_lpc_isa_bridge(): Fix out of bounds write

### DIFF
--- a/PlatboxClient/src/amd/amd_chipset.cpp
+++ b/PlatboxClient/src/amd/amd_chipset.cpp
@@ -14,7 +14,7 @@ DWORD64 g_MmioCfgBaseAddr;
 void _read_lpc_isa_bridge() {	
 	memset(&g_lpc_isa_bridge_registers, 0x00, sizeof(g_lpc_isa_bridge_registers));
     DWORD *pw = (DWORD *) &g_lpc_isa_bridge_registers;
-    for (int i = 0 ; i < sizeof(LPC_ISA_Bridge); i++) {
+    for (int i = 0; i < sizeof(g_lpc_isa_bridge_registers) / sizeof(DWORD); i++) {
         *pw = read_pci_dword(0, 0x14, 3, i);
         pw++;
     }


### PR DESCRIPTION
I think `_read_lpc_isa_bridge` wrongly loops over each _byte_ in the output struct, while reading/writing DWORDs. This means it writes 4x the size of the output struct, so 3x past its end.

This commit/PR fixes that. It is untested (but I think is correct) as the Linux driver from here wouldn't build for me (IIRC, I tried on Ubuntu 20.04 and some RHEL rebuild; I hear others say the driver does build on Ubuntu 22.04). I figured reporting the issue and providing an untested fix is better than not doing anything at all.