### PR TITLE
Fix label error

### DIFF
--- a/PlatboxDrv/linux/driver/kernetix.c
+++ b/PlatboxDrv/linux/driver/kernetix.c
@@ -393,7 +393,7 @@ static long int kernetix_ioctl(struct file *file, unsigned int cmd, unsigned lon
       }
 
       case IOCTL_GET_EFI_MEMMAP_ADDRESS:
-
+      {
         UINT64 *addr_result;	  
         
         if ( copy_from_user(&addr_result, p, sizeof(UINT64)) != 0)
@@ -403,6 +403,7 @@ static long int kernetix_ioctl(struct file *file, unsigned int cmd, unsigned lon
         put_user( (long unsigned int *) &efi.memmap, (unsigned long **)addr_result );    
 
         break;
+      }
 
       case IOCTL_READ_IO_PORT:
         if (copy_from_user(&_io, p, sizeof(IO_PORT_CALL))) {


### PR DESCRIPTION
kernetix.c:397:9: error: a label can only be part of a statement and a declaration is not a statement