### PR TITLE
Update kernetix.c to fix the error when make the PlatboxDrv under linux

### DIFF
--- a/PlatboxDrv/linux/driver/kernetix.c
+++ b/PlatboxDrv/linux/driver/kernetix.c
@@ -393,6 +393,7 @@ static long int kernetix_ioctl(struct file *file, unsigned int cmd, unsigned lon
       }
 
       case IOCTL_GET_EFI_MEMMAP_ADDRESS:
+      {
 
         UINT64 *addr_result;	  
         
@@ -403,6 +404,7 @@ static long int kernetix_ioctl(struct file *file, unsigned int cmd, unsigned lon
         put_user( (long unsigned int *) &efi.memmap, (unsigned long **)addr_result );    
 
         break;
+      }
 
       case IOCTL_READ_IO_PORT:
         if (copy_from_user(&_io, p, sizeof(IO_PORT_CALL))) {


### PR DESCRIPTION
fix the error when make the PlatboxDrv under linux: /Platbox-main/PlatboxDrv/linux/driver/kernetix.c:397:9:error :a label can only be part of a statement and a decl not a statement UINT *addr_result;